### PR TITLE
comparison should be on hostname

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ exports.Extractor   =   function(startUrl,callback,maxConnections){
                                   var toQueueUrl = $(a).attr('href');
                                   if (toQueueUrl){
                                     var parsedUrl  = url.parse(toQueueUrl);
-                                    if (parsedUrl.hostname === null || parsedUrl === host){
+                                    if (parsedUrl.hostname === null || parsedUrl.hostname === host){
                                         toQueueUrl = url.resolve(startUrl,toQueueUrl);
                                         db.isItExists(toQueueUrl).done(function(data){
                                             if (data === 0){


### PR DESCRIPTION
This comparison would never work since `parsedUrl` is an object and host is a string.

Make sure we access the `.hostname` property on the object which is the same as what was stored in `host`
